### PR TITLE
Add pin_factory - fix error of PWMSoftwareFallback

### DIFF
--- a/chapter8/test_distance_sensors.py
+++ b/chapter8/test_distance_sensors.py
@@ -1,12 +1,15 @@
 import time
 from gpiozero import DistanceSensor
+from gpiozero.pins.pigpio import PiGPIOFactory
+factory = PiGPIOFactory()
 
 print("Prepare GPIO Pins")
-sensor_l = DistanceSensor(echo=17, trigger=27, queue_len=2)
-sensor_r = DistanceSensor(echo=5,  trigger=6, queue_len=2)
+# register the sensors and map to Raspberry Pi pins
+sensor_l = DistanceSensor(echo=17, trigger=27, queue_len=2, pin_factory=factory)
+sensor_r = DistanceSensor(echo=5,  trigger=6, queue_len=2, pin_factory=factory)
 
+# print out distance to sensor
 while True:
-    print("Left: {l:.2f}, Right: {r:.2f}".format(
-        l=sensor_l.distance * 100, 
-        r=sensor_r.distance * 100))
+    print(f'Left: {sensor_l.distance * 100:.2f}, Right: {sensor_r.distance * 100:.2f}')
+    # force pause to avoid flooding output
     time.sleep(0.1)


### PR DESCRIPTION
Hi Danny, thank you for this amazing book!

**Justification for request:**
Due to changes in gpiozero, adding the pin_factory parameter, the changes resolve the error (below) resulting from original code: _PWMSoftwareFallback: For more accurate readings, use the pigpio pin factory_. 
   
References are:
-  https://gpiozero.readthedocs.io/en/stable/api_pins.html#changing-the-pin-factory
- https://gpiozero.readthedocs.io/en/stable/api_pins.html#module-gpiozero.pins.pigpio